### PR TITLE
Fix the first minus sign

### DIFF
--- a/amd.js
+++ b/amd.js
@@ -3,11 +3,11 @@ define('jsonFormatSafely', function() {
     data += '';
     var protectedNumber = [];
     data = data.replace(/(?:\d(?:[eE][+-]?)?|\.|\\\\|\\u[a-zA-Z\d]{4})+/g, function($0) {
-      return protectedNumber.push($0) - 1;
+      return protectedNumber.push($0);
     });
     data = JSON.stringify(JSON.parse(data), null, 2);
     return data.replace(/\d+/g, function(index) {
-      return protectedNumber[index];
+      return protectedNumber[index - 1];
     });
   };
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-format-safely",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "json format safely",
   "main": "index.js",
   "scripts": {

--- a/test/basic.js
+++ b/test/basic.js
@@ -92,7 +92,7 @@ test('keep number and unicode', t => {
 });
 
 test('keep struct', t => {
-  let source = { a: 1, b: 2, c: [ 1, 2, 3 ] };
+  let source = { a: -1, b: 2, c: [ 1, 2, 3 ] };
   let json = JSON.stringify(source);
   let result = jsonFormatSafely(json);
   t.is(JSON.stringify(source, null, 2), result);


### PR DESCRIPTION
When the first value to be protected is a negative number, let's say,

```json
[ -1 ]
```

It would be replaced with

```json
[ -0 ]
```

And `JSON.stringify` transforms it to something like

```json
[ 0 ]
```

Boom. The minus sign is gone.